### PR TITLE
Add a helper macro for tracing method invocations

### DIFF
--- a/lcl.h
+++ b/lcl.h
@@ -174,6 +174,9 @@ typedef uint32_t _lcl_component_t;
         }
 #endif
 
+// A convenience macro for tracing method invocations
+#define lcl_trace(_component) lcl_log(_component, lcl_vTrace, @"")
+
 // lcl_configure_by_component(<component>, <level>)
 //
 // <component>: a log component with prefix 'lcl_c'


### PR DESCRIPTION
We have been using LibComponentLogging in our app, and we often found ourselves writing commands like:

  lcl_log(MyComponent, lcl_vTrace, @"")

It is convenient for tracing method invocations but is a bit verbose. This macro reduces the call to a single parameter.
